### PR TITLE
Helper for using ls.m result in Init_Community

### DIFF
--- a/R/Community.R
+++ b/R/Community.R
@@ -11,7 +11,8 @@
 #' @param K carrying capacities of each species
 #' @param d0 death rate when N=0
 #' @param b birth rates (constant)
-#' @param m per capita migration rate in the metacommunity
+#' @param m per capita migration rate in the metacommunity. May be the given as the 
+#' resulting list of the \code{\link{ls.m}} function
 #' @param save.int History saving interval (in simulated time units)
 #' @examples
 #' # Initializes the community (in a global object)
@@ -40,6 +41,8 @@ Init_Community <- function(abundance, interaction, K = 1000, b = 1, m = 0.1, d0 
   if(save.int <= 0) stop("Save interval must be strictly positive")
   if(J > 100000) stop("Maximum number of species reached!")
   if (class(interaction) != "matrix") stop("Interaction must be a matrix!")
+  # Helper for using results from ls.m
+  if (class(m) == "list" & "m" %in% names(m)) m = m$m 
   if (length(K)==1) K <- rep(K, J)
   if (length(d0)==1) d0 <- rep(d0, J)
   if (length(b)==1) b <- rep(b, J)

--- a/man/Community.Rd
+++ b/man/Community.Rd
@@ -28,7 +28,8 @@ history()
 
 \item{b}{birth rates (constant)}
 
-\item{m}{per capita migration rate in the metacommunity}
+\item{m}{per capita migration rate in the metacommunity. May be the given as the 
+resulting list of the \code{\link{ls.m}} function}
 
 \item{d0}{death rate when N=0}
 

--- a/vignettes/GillesCom.Rnw
+++ b/vignettes/GillesCom.Rnw
@@ -96,7 +96,7 @@ For performance reasons, this package works with a \emph{global} community objec
 active simulation at any given time. In order to initialize a community, use the function 
 \code{Init\_Community}. Notice that you don't need to assign this call to any object:
 <<Init>>=
-Init_Community(abundance=rep(0, N), interaction=random, b=1, m = migration$m)
+Init_Community(abundance=rep(0, N), interaction=random, b=1, m = migration)
 @
 
 The arguments $m$, $b$ and $d0$ of this function are expanded to vectors of the appropriate length, if


### PR DESCRIPTION
A simple check inside the Init_Community to help using the new list from ls.m. Now Init_Community checks whether the "m" parameter is a list with an m component, and if so, uses the "m" component as the migration rates.
